### PR TITLE
Add release channels

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,7 +18,7 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       LINODE_TOKEN: ${{ secrets.LINODE_TOKEN }}
-      RELEASE_CHANNEL: ${{ github.event_name == 'push' && 'edge' || github.head_ref }}
+      RELEASE_CHANNEL: ${{ github.event_name == 'push' && 'edge' || 'dev-' + github.head_ref }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,6 +18,7 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       LINODE_TOKEN: ${{ secrets.LINODE_TOKEN }}
+      RELEASE_CHANNEL: ${{ github.event_name == 'push' && 'edge' || github.head_ref }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -25,5 +26,5 @@ jobs:
         uses: hashicorp/setup-packer@v3.1.0
         with:
           version: v1.14.2
-      - name: Build image(s)
-        run: make BUILD=linode
+      - name: Build image (${{ env.RELEASE_CHANNEL }})
+        run: make BUILD=linode CHANNEL=${RELEASE_CHANNEL}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,7 +18,7 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       LINODE_TOKEN: ${{ secrets.LINODE_TOKEN }}
-      RELEASE_CHANNEL: ${{ github.event_name == 'push' && 'edge' || 'dev-' + github.head_ref }}
+      RELEASE_CHANNEL: ${{ github.event_name == 'push' && 'edge' || format('dev-{0}', github.head_ref) }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 BUILD=qemu
+CHANNEL=snapshot-$(shell git rev-parse --short HEAD)
 
 .PHONY: default
 default: check-fmt clean build
@@ -8,7 +9,7 @@ build: $(BUILD)/packer-manifest.json
 
 $(BUILD)/packer-manifest.json:
 	cd $(BUILD) && packer init .
-	cd $(BUILD) && packer build .
+	cd $(BUILD) && packer build -var "channel=$(CHANNEL)" .
 
 .PHONY: clean
 clean:

--- a/linode/build.pkr.hcl
+++ b/linode/build.pkr.hcl
@@ -14,10 +14,5 @@ build {
     ]
   }
 
-  post-processor "manifest" {
-    custom_data = {
-      ubuntu_release = var.ubuntu_release
-      ubuntu_version = local.ubuntu_version
-    }
-  }
+  post-processor "manifest" {}
 }

--- a/linode/packer.pkr.hcl
+++ b/linode/packer.pkr.hcl
@@ -23,6 +23,12 @@ variable "linode_api_token" {
   default = env("LINODE_TOKEN")
 }
 
+variable "channel" {
+  type        = string
+  default     = "dev"
+  description = "Channel name to tag the image with (e.g. stable, dev, etc)"
+}
+
 variable "ubuntu_release" {
   type        = string
   default     = "jammy"

--- a/linode/packer.pkr.hcl
+++ b/linode/packer.pkr.hcl
@@ -14,8 +14,9 @@ locals {
   }
 
   ubuntu_version = lookup(local.ubuntu_releases, var.ubuntu_release, "22.04")
-
-  timestamp = regex_replace(timestamp(), "[- TZ:]", "")
+  timestamp      = regex_replace(timestamp(), "[- TZ:]", "")
+  regions        = ["eu-central"]
+  # regions = ["eu-central", "ap-south"]
 }
 
 variable "linode_api_token" {

--- a/linode/source.pkr.hcl
+++ b/linode/source.pkr.hcl
@@ -2,7 +2,7 @@ source "linode" "ubuntu" {
   image             = "linode/ubuntu${local.ubuntu_version}"
   image_description = "Base image for minecraft servers."
   image_label       = "mc-ubuntu${local.ubuntu_version}-${var.channel}"
-  image_regions     = ["eu-central", "ap-south"]
+  # image_regions     = ["eu-central", "ap-south"]
   instance_label    = "mc-temp-packer-ubuntu${local.ubuntu_version}-${var.channel}-${local.timestamp}"
   instance_type     = "g6-nanode-1"
   linode_token      = "${var.linode_api_token}"

--- a/linode/source.pkr.hcl
+++ b/linode/source.pkr.hcl
@@ -1,14 +1,14 @@
 source "linode" "ubuntu" {
   image             = "linode/ubuntu${local.ubuntu_version}"
   image_description = "Base image for minecraft servers."
-  image_label       = "mc-ubuntu${local.ubuntu_version}-${local.timestamp}"
+  image_label       = "mc-ubuntu${local.ubuntu_version}-${var.channel}"
   image_regions     = ["eu-central", "ap-south"]
-  instance_label    = "mc-temp-packer-ubuntu${local.ubuntu_version}-${local.timestamp}"
+  instance_label    = "mc-temp-packer-ubuntu${local.ubuntu_version}-${var.channel}-${local.timestamp}"
   instance_type     = "g6-nanode-1"
   linode_token      = "${var.linode_api_token}"
   region            = "eu-central"
   ssh_username      = "root"
-  instance_tags     = ["managed-by:packer", "stage:dev", "build:ubuntu${local.ubuntu_version}"]
+  instance_tags     = ["managed-by:packer", "channel:${var.channel}", "build:ubuntu${local.ubuntu_version}"]
 
   metadata {
     user_data = base64encode(file("${path.root}/../init/user-data"))

--- a/linode/source.pkr.hcl
+++ b/linode/source.pkr.hcl
@@ -1,12 +1,12 @@
 source "linode" "ubuntu" {
   image             = "linode/ubuntu${local.ubuntu_version}"
   image_description = "Base image for minecraft servers."
-  image_label       = "mc-ubuntu${local.ubuntu_version}-${var.channel}"
-  # image_regions     = ["eu-central", "ap-south"]
+  image_label       = "mc-server-ubuntu${local.ubuntu_version}-${var.channel}"
+  image_regions     = local.regions
   instance_label    = "mc-temp-packer-ubuntu${local.ubuntu_version}-${var.channel}-${local.timestamp}"
   instance_type     = "g6-nanode-1"
   linode_token      = "${var.linode_api_token}"
-  region            = "eu-central"
+  region            = local.regions[0]
   ssh_username      = "root"
   instance_tags     = ["managed-by:packer", "channel:${var.channel}", "build:ubuntu${local.ubuntu_version}"]
 

--- a/qemu/build.pkr.hcl
+++ b/qemu/build.pkr.hcl
@@ -1,5 +1,5 @@
 build {
-  name = "ubuntu"
+  name = "mc-server-ubuntu"
 
   sources = [
     "source.qemu.ubuntu",
@@ -14,10 +14,5 @@ build {
     ]
   }
 
-  post-processor "manifest" {
-    custom_data = {
-      ubuntu_release = var.ubuntu_release
-      ubuntu_version = local.ubuntu_version
-    }
-  }
+  post-processor "manifest" {}
 }

--- a/qemu/packer.pkr.hcl
+++ b/qemu/packer.pkr.hcl
@@ -21,3 +21,9 @@ variable "ubuntu_release" {
   default     = "jammy"
   description = "Ubuntu codename version (i.e. 20.04 is focal and 22.04 is jammy)"
 }
+
+variable "channel" {
+  type        = string
+  default     = "dev"
+  description = "Channel name to tag the image with (e.g. stable, dev, etc)"
+}

--- a/qemu/source.pkr.hcl
+++ b/qemu/source.pkr.hcl
@@ -1,7 +1,7 @@
 source "qemu" "ubuntu" {
   accelerator      = "kvm"
   output_directory = "output/qemu-ubuntu"
-  vm_name          = "mc-ubuntu${local.ubuntu_version}.img"
+  vm_name          = "mc-ubuntu${local.ubuntu_version}-${var.channel}.img"
 
   iso_checksum = "file:https://cloud-images.ubuntu.com/${var.ubuntu_release}/current/SHA256SUMS"
   iso_url      = "https://cloud-images.ubuntu.com/${var.ubuntu_release}/current/${var.ubuntu_release}-server-cloudimg-amd64.img"

--- a/qemu/source.pkr.hcl
+++ b/qemu/source.pkr.hcl
@@ -1,7 +1,7 @@
 source "qemu" "ubuntu" {
   accelerator      = "kvm"
   output_directory = "output/qemu-ubuntu"
-  vm_name          = "mc-ubuntu${local.ubuntu_version}-${var.channel}.img"
+  vm_name          = "mc-server-ubuntu${local.ubuntu_version}-${var.channel}.img"
 
   iso_checksum = "file:https://cloud-images.ubuntu.com/${var.ubuntu_release}/current/SHA256SUMS"
   iso_url      = "https://cloud-images.ubuntu.com/${var.ubuntu_release}/current/${var.ubuntu_release}-server-cloudimg-amd64.img"


### PR DESCRIPTION
Splitting image builds into release channels allows us to propagate different image versions into different environments. This PR sets up release channels based on image labels using the following convention (only supported `<os-variant>` is currently `ubuntu22.04`):

- `mc-server-<os-variant>-stable` - Stable version, currently not propagated
- `mc-server-<os-variant>-edge` - Tracking `main`, for sandbox, testing and development
- `mc-server-<os-variant>-dev-<branch-name>` - Tracking development branches, for testing
- `mc-server-<os-variant>-snapshot-<commit-ref>` - Local development builds
