### PR TITLE
Cleanup: Group images by versions

### DIFF
--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -1,4 +1,4 @@
-name: daily-cleanup
+name: Daily Cleanup
 
 on:
   schedule:
@@ -28,5 +28,5 @@ jobs:
       - name: Install pipenv
         run: python -m pip install -r requirements.txt
 
-      - name: Run repository script
+      - name: Run cleanup script
         run: python tools/cleanup.py

--- a/tools/cleanup.py
+++ b/tools/cleanup.py
@@ -9,54 +9,55 @@ from datetime import datetime, timedelta
 from urllib.parse import urlencode
 
 
-log_level = os.getenv("LOG_LEVEL", "INFO").upper()
-logging.basicConfig(level=log_level, stream=os.sys.stderr)
-
-
+STABLE_CHANNELS = ["stable", "edge"]
+MAX_AGE_DAYS = 7
 REPO="github.com/joerx/packer-linode-minecraft"
 LINODE_TOKEN = os.getenv("LINODE_TOKEN")
 DRY_RUN=os.getenv("DRY_RUN", "0") in ["1", "true", "True", "TRUE"]
+LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
+
+
+logging.basicConfig(level=LOG_LEVEL, stream=os.sys.stderr)
 
 
 def main():
   for image in find_deprecated_images():
-    delete_image(image)
+    delete_image(image, dry_run=DRY_RUN)
 
 
-def map_tags(tags):
-  tags_dict = {}
-  for tag in tags:
-    if ":" in tag:
-      k, v = tag.split(":")
-    else:
-      k, v = tag, None
-    tags_dict[k] = v
-  return tags_dict
+def find_deprecated_images(stable_channels=STABLE_CHANNELS, max_age=timedelta(days=MAX_AGE_DAYS), repo=REPO):
+  """Find all image versions that are considered deprecated based on their channel and age."""
+
+  images = find_images(repo=repo)
+  image_versions = group_images_by_label(images)
+
+  for image in image_versions:
+    for version in image["versions"]:
+      label = image["label"]
+      channel = version["tags"].get("channel")
+      age = datetime.now() - version["created"]
+
+      # Only the latest version of each stable channel is retained
+      if channel in stable_channels and version["is_latest"]:
+        logging.debug(f"Image '{label}', channel='{channel}', skipping latest version of stable release")
+        continue
+        
+      # All other image versions will be retained only if within max age
+      if age <= max_age:
+        logging.debug(f"Image '{label}', channel='{channel}', age {age}, within max age, retaining")
+        continue
+
+      logging.debug(f"Image '{label}', channel='{channel}', age {age}, marking as deprecated")
+      yield version
 
 
-def find_deprecated_images(stable_channels = ["stable", "edge"], max_age = timedelta(days=7)):
-  for image in find_images():
-    channel = image["tags"].get("channel")
-    label = image["label"]
-
-    if channel in stable_channels:
-      logging.debug(f"Image '{label}', channel='{channel}', skipping")
-      continue
-      
-    age = datetime.now() - image["created"]
-
-    if age <= max_age:
-      logging.debug(f"Image '{label}', channel='{channel}', age {age}, within max age, retaining")
-      continue
-
-    logging.debug(f"Image '{label}', channel='{channel}', age {age}, marked deprecated")
-    yield image
-
-
-def delete_image(image):
+def delete_image(image, dry_run=False):
     logging.info(f"Deleting image '{image['label']}' (ID: {image['id']})")
-    linode_api_request(f"images/{image['id']}", method="delete")
-    logging.info(f"Image '{image['label']}' deleted")
+    if dry_run:
+      logging.info(f"Image '{image['label']}' would have been deleted (dry run)")
+    else:
+      linode_api_request(f"images/{image['id']}", method="delete")
+      logging.info(f"Image '{image['label']}' deleted")
 
 
 def linode_api_request(endpoint, method="get", **kwargs):
@@ -75,8 +76,40 @@ def linode_api_request(endpoint, method="get", **kwargs):
   return response.json()
 
 
-def find_images():
+def group_images_by_label(images):
+  """Group images by their label, collecting all versions under each label."""
+
+  image_map = dict()
+  images = sorted(images, key=lambda i: i["created"], reverse=True)
+  
+  for image in images:
+    label = image["label"]
+    is_latest = False
+
+    if label not in image_map:
+      is_latest = True
+      image_map[label] = {
+        "label": label,
+        "versions": []
+      }
+
+    image_map[label]["versions"].append({
+      "label": image["label"],
+      "id": image["id"],
+      "created": image["created"],
+      "status": image["status"],
+      "tags": image["tags"],
+      "is_latest": is_latest,
+    })
+
+  return image_map.values()
+
+
+def find_images(repo):
+  """Find all images matching the given repo tag. Images are grouped by label, with all versions included."""
+
   cur_page = 0
+  images = []
 
   while True:
     body = linode_api_request("images", page=cur_page+1, page_size=50)
@@ -89,23 +122,34 @@ def find_images():
       if image["is_public"]:
         continue
 
+      # Make sure we only get images from this repo
       tags = map_tags(image["tags"])
-      if tags.get("repo") != REPO:
-        logging.debug(f"Image '{image['label']}': repo tag '{tags.get('repo')}' does not match '{REPO}', skipping")
+      if tags.get("repo") != repo:
+        logging.debug(f"Image '{image['label']}': repo tag '{tags.get('repo')}' does not match '{repo}', skipping")
         continue
 
-      yield {
+      images.append({
+        "label": image["label"],
         "created": datetime.strptime(image["created"], '%Y-%m-%dT%H:%M:%S'),
         "id": image["id"],
-        "label": image["label"],
-        "public": image["is_public"],
         "status": image["status"],
         "tags": map_tags(image["tags"]),
-      }
+      })
 
     if cur_page >= num_pages:
-      break
+      return images
     
+
+def map_tags(tags):
+  tags_dict = {}
+  for tag in tags:
+    if ":" in tag:
+      k, v = tag.split(":")
+    else:
+      k, v = tag, True
+    tags_dict[k] = v
+  return tags_dict
+
 
 if __name__ == "__main__":
   main()


### PR DESCRIPTION
Linode API allows multiple images with the same label to exist. Rebuilding an image will simply create a new image with the same label. We want to treat these as versions of the same build, so this PR updates the clean-up script to group versions. The latest version of each stable release will be retained, all others will be deleted.
