### PR TITLE
Adjust retention for cleanup script

### DIFF
--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -1,12 +1,16 @@
-name: Daily Cleanup
+name: cleanup
 
 on:
+  workflow_dispatch: {}
   schedule:
     - cron: '0 3 * * *'  # runs daily at 03:00 UTC
-  workflow_dispatch: {}
+  pull_request:
+    branches:
+      - main
 
 jobs:
   run-script:
+    name: Run cleanup script
     runs-on: ubuntu-latest
     environment: build
     permissions:
@@ -14,7 +18,8 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       LINODE_TOKEN: ${{ secrets.LINODE_TOKEN }}
-      DRY_RUN: "1"
+      DRY_RUN: ${{ github.event_name == 'pull_request' && '1' || '0' }}
+      MAX_AGE_DAYS: "3"
       LOG_LEVEL: "DEBUG"
     steps:
       - name: Checkout repository

--- a/tools/cleanup.py
+++ b/tools/cleanup.py
@@ -10,9 +10,11 @@ from urllib.parse import urlencode
 
 
 STABLE_CHANNELS = ["stable", "edge"]
-MAX_AGE_DAYS = 7
+MAX_AGE_DAYS = int(os.getenv("MAX_AGE_DAYS", "7"))
 REPO="github.com/joerx/packer-linode-minecraft"
+
 LINODE_TOKEN = os.getenv("LINODE_TOKEN")
+
 DRY_RUN=os.getenv("DRY_RUN", "0") in ["1", "true", "True", "TRUE"]
 LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
 


### PR DESCRIPTION
Setting retention to 3 days and running the cleanup script in dry run mode on pull requests for validation.
