### PR TITLE
Use -depth in Makefile to delete output dirs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,6 +17,7 @@ jobs:
       contents: write
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PACKER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_API_TOKEN }} # Avoid rate limiting, see https://developer.hashicorp.com/packer/docs/configure#packer_github_api_token
       LINODE_TOKEN: ${{ secrets.LINODE_TOKEN }}
       RELEASE_CHANNEL: ${{ github.event_name == 'push' && 'edge' || format('dev-{0}', github.head_ref) }}
     steps:

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ packer/$(BUILD)/packer-manifest.json:
 
 .PHONY: clean
 clean:
-	find packer -type d -name output -exec rm -rf {} \;
+	find packer -depth -type d -name output -exec rm -rf {} \;
 	find packer -name 'packer-manifest.json' -exec rm {} \;
 
 # Don't use `-exec` below since it will ignrore non-zero exit codes


### PR DESCRIPTION
This is to avoid "No such file or directory" error when recursively deleting output directories. See https://stackoverflow.com/questions/66912915/find-exec-rm-no-such-file-or-directory for more information.
