### PR TITLE
Fix naming of secret for PACKER_GITHUB_API_TOKEN

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,7 +17,7 @@ jobs:
       contents: write
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      PACKER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_API_TOKEN }} # Avoid rate limiting, see https://developer.hashicorp.com/packer/docs/configure#packer_github_api_token
+      PACKER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Avoid rate limiting, see https://developer.hashicorp.com/packer/docs/configure#packer_github_api_token
       LINODE_TOKEN: ${{ secrets.LINODE_TOKEN }}
       RELEASE_CHANNEL: ${{ github.event_name == 'push' && 'edge' || format('dev-{0}', github.head_ref) }}
     steps:


### PR DESCRIPTION
Referenced the wrong secret name for `PACKER_GITHUB_API_TOKEN`, leading to packer builds failing due to GH rate limiting errors.
